### PR TITLE
Minimum versions for Ignition dependencies

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -8,7 +8,7 @@ Build-Depends: cmake,
                doxygen,
                libignition-cmake2-dev,
                libignition-common3-dev,
-               libignition-gazebo2-dev,
+               libignition-gazebo2-dev (>= 2.18.0),
                libignition-gui2-dev,
                libignition-msgs4-dev,
                libignition-plugin-dev,
@@ -37,7 +37,7 @@ Architecture: any
 Section: libdevel
 Depends: libignition-cmake2-dev,
 	 libignition-common3-dev,
-	 libignition-gazebo2-dev,
+	 libignition-gazebo2-dev (>= 2.18.0),
 	 libignition-gui2-dev,
 	 libignition-msgs4-dev,
 	 libignition-plugin-dev,
@@ -49,7 +49,7 @@ Depends: libignition-cmake2-dev,
 	 qtquickcontrols2-5-dev,
 	 libqt5core5a,
 	 libignition-launch (= ${binary:Version}),
-	 ignition-gazebo2,
+	 ignition-gazebo2 (>= 2.18.0),
          ${misc:Depends}
 Multi-Arch: same
 Description: Ignition Robotics Launch Library - Launch libraries


### PR DESCRIPTION
The main motivation is that right now, if a user only calls `sudo apt install libignition-launch1` to upgrade only this package, they end up with a broken system because the dependencies are not up-to-date. The result is a runtime error when running `ign launch` and it can't load the library.

I based myself on the versions currently required on [ign-launch's CMakeLists](https://github.com/ignitionrobotics/ign-launch/blob/ign-launch1/CMakeLists.txt), but we haven't been very good about updating these, so some could be out of date.

See the equivalent PR for `ign-gazebo2`: https://github.com/ignition-release/ign-gazebo2-release/pull/1